### PR TITLE
Use Zenbot's 'list-strategies' command in strategy importer

### DIFF
--- a/app/Utility/StrategyImporter.php
+++ b/app/Utility/StrategyImporter.php
@@ -66,15 +66,21 @@ class StrategyImporter
                 $strategy->save();
             }
             else if (substr_count($line, '--') > 0) {
+                $default = $this->extract_option_default_value(trim($line));
+                $unit = $this->extract_option_unit(trim($line));
+
+                // Convert hours to minutes
+                if ($unit === 'h') {
+                    $unit = 'm';
+                    $default = $default * 60;
+                }
+
                 $strategy->options()->save(new StrategyOption([
                     'name' => $this->extract_option_name(trim($line)),
                     'description' => $this->extract_option_description(trim($line)),
-                    'default' => $this->extract_option_default_value(trim($line)),
-                    'unit' => $this->extract_option_unit(trim($line)),
-                    'step' => $this->get_step_size(
-                        $this->extract_option_default_value(trim($line)), 
-                        $this->extract_option_unit(trim($line))
-                    )
+                    'default' => $default,
+                    'unit' => $unit,
+                    'step' => $this->get_step_size($default, $unit)
                 ]));
             }
         }

--- a/app/Utility/StrategyImporter.php
+++ b/app/Utility/StrategyImporter.php
@@ -41,7 +41,7 @@ class StrategyImporter
         $strategy = null;
         foreach ($lines as $i => $line) {
             if (
-                strlen($line) > 1 &&                      // Line has more than one character
+                strlen($line) > 1 &&         // Line has more than one character
                 substr($line, 0, 1) !== ' '  // First character is not a space
             ) {
                 // Every strategy should have 'description' or 'options' on the next line


### PR DESCRIPTION
In this pull request, I'm switching to getting the strategy list from the `zenbot list-strategies` command instead of a markdown file. This way, it should always be up-to-date with all the available strategies in Zenbot.

I also added a conversion from hours to minutes, as this allows users to use smaller steps.